### PR TITLE
fix Tokenizer not found

### DIFF
--- a/Lucene_Structure_Mapping-master/Lucene_Searchdoc.py
+++ b/Lucene_Structure_Mapping-master/Lucene_Searchdoc.py
@@ -1,6 +1,5 @@
 import unicodedata
 import regex as re
-from dhr.utils.tokenizers import SimpleTokenizer
 import json
 import argparse
 from tqdm import tqdm
@@ -8,6 +7,8 @@ from multiprocessing import Pool
 from multiprocessing import Process, Manager
 import sys
 import csv
+sys.path.append("..")
+from dhr.utils.tokenizers import SimpleTokenizer
 
 csv.field_size_limit(sys.maxsize)
 

--- a/Lucene_Structure_Mapping-master/Lucene_Searchdoc.py
+++ b/Lucene_Structure_Mapping-master/Lucene_Searchdoc.py
@@ -1,6 +1,6 @@
 import unicodedata
 import regex as re
-from Tokenizer import SimpleTokenizer
+from dhr.utils.tokenizers import SimpleTokenizer
 import json
 import argparse
 from tqdm import tqdm

--- a/Lucene_Structure_Mapping-master/Lucene_Searcher.py
+++ b/Lucene_Structure_Mapping-master/Lucene_Searcher.py
@@ -1,6 +1,6 @@
 import unicodedata
 import regex as re
-from Tokenizer import SimpleTokenizer
+from dhr.utils.tokenizers import SimpleTokenizer
 import json
 import sys
 from tqdm import tqdm

--- a/Lucene_Structure_Mapping-master/Lucene_Searcher.py
+++ b/Lucene_Structure_Mapping-master/Lucene_Searcher.py
@@ -1,6 +1,5 @@
 import unicodedata
 import regex as re
-from dhr.utils.tokenizers import SimpleTokenizer
 import json
 import sys
 from tqdm import tqdm
@@ -8,6 +7,9 @@ from multiprocessing import Pool
 from multiprocessing import Process, Manager
 import sys
 import csv
+sys.path.append("..")
+from dhr.utils.tokenizers import SimpleTokenizer
+
 csv.field_size_limit(sys.maxsize)
 import argparse
 

--- a/Lucene_Structure_Mapping-master/build_docs_example.py
+++ b/Lucene_Structure_Mapping-master/build_docs_example.py
@@ -2,11 +2,13 @@ import csv
 import json
 import unicodedata
 import regex as re
-from dhr.utils.tokenizers import SimpleTokenizer
 import argparse
 from multiprocessing import Pool
 from tqdm import tqdm
 import sys
+sys.path.append("..")
+from dhr.utils.tokenizers import SimpleTokenizer
+
 csv.field_size_limit(sys.maxsize)
 def _normalize(text):
     return unicodedata.normalize("NFD", text)

--- a/Lucene_Structure_Mapping-master/build_docs_example.py
+++ b/Lucene_Structure_Mapping-master/build_docs_example.py
@@ -2,7 +2,7 @@ import csv
 import json
 import unicodedata
 import regex as re
-from Tokenizer import SimpleTokenizer
+from dhr.utils.tokenizers import SimpleTokenizer
 import argparse
 from multiprocessing import Pool
 from tqdm import tqdm

--- a/Lucene_Structure_Mapping-master/build_psgs_example.py
+++ b/Lucene_Structure_Mapping-master/build_psgs_example.py
@@ -2,11 +2,12 @@ import csv
 import json
 from Has_answer import _normalize, has_answer
 from fuzzywuzzy import process
-from dhr.utils.tokenizers import SimpleTokenizer
 import argparse
 from multiprocessing import Pool
 from tqdm import tqdm
 import sys
+sys.path.append("..")
+from dhr.utils.tokenizers import SimpleTokenizer
 
 csv.field_size_limit(sys.maxsize)
 import html

--- a/Lucene_Structure_Mapping-master/build_psgs_example.py
+++ b/Lucene_Structure_Mapping-master/build_psgs_example.py
@@ -2,7 +2,7 @@ import csv
 import json
 from Has_answer import _normalize, has_answer
 from fuzzywuzzy import process
-from Tokenizer import SimpleTokenizer
+from dhr.utils.tokenizers import SimpleTokenizer
 import argparse
 from multiprocessing import Pool
 from tqdm import tqdm


### PR DESCRIPTION
Hello, the `Tokenizer` is not defined in Lucene_Structure_Mapping-master.